### PR TITLE
chore(security): Pin GitHub Actions and Docker images

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/base:bookworm
+FROM mcr.microsoft.com/devcontainers/base:bookworm@sha256:17e6cc517b483d1108b333d4c34352b0a21617f0117052e9b259d47113a9dc37
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends gnuplot pip postgresql-client

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -21,7 +21,7 @@ services:
 
   db:
     # TODO switch back to official postgis image when arm64 is supported
-    image: ghcr.io/baosystems/postgis:18-3.6
+    image: ghcr.io/baosystems/postgis:18-3.6@sha256:99383bd8192ff0d003751914c12aae79f20b09f9a64da8e17f1baf8fa53133e9
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,12 @@ updates:
       interval: "weekly"
       day: "friday"
 
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 16
     steps:
-      - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Install gnuplot
@@ -48,7 +48,7 @@ jobs:
           cd tools/generic-tools/
           npm run db:stop
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           title: New benchmark results
           branch: benchmark/ci-benchmark

--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - name: apt-get update
         run: sudo apt-get update # to avoid error when installing Playwright
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Install Playwright Browsers
@@ -26,7 +26,7 @@ jobs:
           TURBO_TEAM: ${{ secrets.DOSSIERHQ_TURBO_TEAM }}
           TURBO_TOKEN: ${{ secrets.DOSSIERHQ_TURBO_TOKEN }}
       - name: Run Chromatic for react-components2
-        uses: chromaui/action@v16
+        uses: chromaui/action@cad40970f69e7a6a5bef4ddfe42c01309ba17cb1 # v16.6.0
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: libraries/react-components2

--- a/.github/workflows/dependency-maintenance.yaml
+++ b/.github/workflows/dependency-maintenance.yaml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Set up pnpm global bin directory
         run: |
@@ -37,7 +37,7 @@ jobs:
         run: pnpm dedupe
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "chore(deps): Deduplicate pnpm lockfile"
           title: "chore(deps): Deduplicate pnpm lockfile"
@@ -57,9 +57,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && github.event.schedule == '0 3 * * 2')
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Update mise tools
         run: mise up --bump
@@ -74,7 +74,7 @@ jobs:
           fi
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "chore(tools): Update tool versions"
           title: "chore(tools): Update tool versions"

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,15 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 16
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cache blog/next-web next
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             app/blog/.next/cache/
             examples/next-web/.next/cache/
           key: ${{ runner.os }}-next-${{ hashFiles('pnpm-lock.yaml') }}
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: start db

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
-      - uses: jdx/mise-action@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create .npmrc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   postgres:
     # TODO switch back to official postgis image when arm64 is supported
-    image: ghcr.io/baosystems/postgis:18-3.6
+    image: ghcr.io/baosystems/postgis:18-3.6@sha256:99383bd8192ff0d003751914c12aae79f20b09f9a64da8e17f1baf8fa53133e9
     ports:
       - published: 5432
         target: 5432


### PR DESCRIPTION
## Summary
- Pin every `uses:` in workflows to a 40-char commit SHA with a trailing `# vX.Y.Z` comment (Dependabot reads the comment to offer upgrades).
- Pin every container image to its `@sha256:` manifest-index digest (`docker-compose.yml`, `.devcontainer/docker-compose.yml`, `.devcontainer/Dockerfile`).
- Add a `docker` ecosystem entry to `.github/dependabot.yml` for `/.devcontainer` so the Dockerfile digest keeps getting weekly update PRs.

Tags are mutable — upstream publishers (or an attacker who compromises them) can re-point them silently, which is how several real-world CI supply-chain incidents started. SHAs and digests make the builds byte-reproducible and close that surface.

### Pinned actions
| Action | SHA | Version |
|---|---|---|
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6.0.2 |
| `actions/cache` | `27d5ce7f107fe9357f9df03efb73ab90386fccae` | v5.0.5 |
| `jdx/mise-action` | `1648a7812b9aeae629881980618f079932869151` | v4.0.1 |
| `chromaui/action` | `cad40970f69e7a6a5bef4ddfe42c01309ba17cb1` | v16.6.0 |
| `changesets/action` | `6a0a831ff30acef54f2c6aa1cbbc1096b066edaf` | v1.7.0 |
| `peter-evans/create-pull-request` | `5f6978faf089d4d20b00c7766989d076bb2fc7f1` | v8.1.1 |

### Pinned images
| Image | Digest |
|---|---|
| `ghcr.io/baosystems/postgis:18-3.6` | `sha256:99383bd8192ff0d003751914c12aae79f20b09f9a64da8e17f1baf8fa53133e9` |
| `mcr.microsoft.com/devcontainers/base:bookworm` | `sha256:17e6cc517b483d1108b333d4c34352b0a21617f0117052e9b259d47113a9dc37` |

## Test plan
- [ ] `nodejs.yml` runs green on the PR
- [ ] `browser.yml` runs green on the PR
- [ ] `dependency-maintenance.yaml` can still create PRs (manually `workflow_dispatch` on `main` after merge)
- [ ] `benchmark.yml` — manually `workflow_dispatch` to confirm `peter-evans/create-pull-request` pin works
- [ ] `release.yml` — will be exercised on the next merge to `main`
- [ ] Devcontainer "Rebuild Container" still succeeds with the pinned base image