### PR TITLE
chore(security): Add zizmor workflow audit

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,6 +12,8 @@ jobs:
     timeout-minutes: 16
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/dependency-maintenance.yaml
+++ b/.github/workflows/dependency-maintenance.yaml
@@ -9,15 +9,19 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   pnpm-dedupe:
     runs-on: ubuntu-slim
     timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
@@ -56,8 +60,13 @@ jobs:
     # Only run weekly on Tuesday at 3 AM UTC
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && github.event.schedule == '0 3 * * 2')
     timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,6 +8,8 @@ jobs:
     timeout-minutes: 16
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Cache blog/next-web next
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Checkout Repo
+        # zizmor: ignore[artipacked] changesets/action pushes the release PR branch, and the Publish step does git push --tags
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - name: Install dependencies

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+name: zizmor
+
+on:
+  push:
+    branches: [main]
+    paths: [".github/workflows/**"]
+  pull_request:
+    paths: [".github/workflows/**"]
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3


### PR DESCRIPTION
## Summary
- Add `.github/workflows/zizmor.yml` to audit GitHub Actions workflows on PRs and pushes that touch `.github/workflows/**`, uploading SARIF results to the Code Scanning tab (free on this public repo — no GHAS needed).
- Fix every finding zizmor surfaces on the existing workflows:
  - `persist-credentials: false` on every `actions/checkout` that doesn't need persisted git creds (`benchmark.yml`, `browser.yml`, `nodejs.yml`, both jobs in `dependency-maintenance.yaml`).
  - Move `contents: write` / `pull-requests: write` from workflow-level to per-job in `dependency-maintenance.yaml`.
  - `release.yml` keeps persisted creds — `changesets/action` pushes the "Version Packages" PR branch and the Publish step does `git push --tags`. Suppressed inline with a `# zizmor: ignore[artipacked]` comment explaining why.

Local run: `uvx zizmor .github/workflows/` → `No findings to report. Good job! (1 ignored, 35 suppressed)`.

## Test plan
- [ ] zizmor workflow runs green on this PR
- [ ] After merge: confirm no unexpected alerts in Security → Code scanning
- [ ] Confirm next `release.yml` run still creates/publishes correctly (credential-persistence path unchanged)
- [ ] Confirm next `dependency-maintenance` run still opens its automated PRs (per-job permissions still grant `contents: write` + `pull-requests: write`)