### PR TITLE
ci: harden GitHub Actions workflows per zizmor audit

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,12 +4,18 @@ on:
     - cron: "0 0 1 * *"
   workflow_dispatch:
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   build:
+    name: Run benchmark
     runs-on: ubuntu-latest
     timeout-minutes: 16
+    permissions:
+      contents: write # peter-evans/create-pull-request commits benchmark results to a branch
+      pull-requests: write # peter-evans/create-pull-request opens the benchmark results PR
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -2,8 +2,12 @@ name: Browser Integration Tests
 on: [push]
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 jobs:
   build:
+    name: Browser integration tests
     runs-on: ubuntu-latest
     timeout-minutes: 16
     steps:

--- a/.github/workflows/dependency-maintenance.yaml
+++ b/.github/workflows/dependency-maintenance.yaml
@@ -11,13 +11,18 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   pnpm-dedupe:
+    name: pnpm dedupe
     runs-on: ubuntu-slim
     timeout-minutes: 10
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write # peter-evans/create-pull-request pushes the dedupe branch
+      pull-requests: write # peter-evans/create-pull-request opens the dedupe PR
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -56,13 +61,14 @@ jobs:
           labels: dependencies
 
   mise-tool-updates:
+    name: mise tool updates
     runs-on: ubuntu-slim
     # Only run weekly on Tuesday at 3 AM UTC
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && github.event.schedule == '0 3 * * 2')
     timeout-minutes: 10
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write # peter-evans/create-pull-request pushes the tool-update branch
+      pull-requests: write # peter-evans/create-pull-request opens the tool-update PR
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -2,8 +2,12 @@ name: Node CI
 on: [push]
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 jobs:
   build:
+    name: Build and test
     runs-on: ubuntu-latest
     timeout-minutes: 16
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,21 @@
 name: Release
 permissions:
-  contents: write
-  id-token: write
-  pull-requests: write
+  contents: read
 on:
   push:
     branches:
       - main
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   release:
     name: Release
     runs-on: ubuntu-slim
+    permissions:
+      contents: write # changesets/action pushes the release PR branch; Publish step runs `git push --tags`
+      id-token: write # required by npm for publishing with provenance
+      pull-requests: write # changesets/action opens/updates the "Version Packages" release PR
     steps:
       - name: Checkout Repo
         # zizmor: ignore[artipacked] changesets/action pushes the release PR branch, and the Publish step does git push --tags

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -6,17 +6,26 @@ on:
     paths: [".github/workflows/**"]
   pull_request:
     paths: [".github/workflows/**"]
+  schedule:
+    # Re-scan weekly so newly-published advisories against pinned actions are caught
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
 
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   zizmor:
+    name: Audit workflows
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read
-      security-events: write
+      security-events: write # zizmor-action uploads SARIF results to GitHub code scanning
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Summary
- Moves write-scoped permissions (`contents`, `pull-requests`, `id-token`) from workflow level down to the consuming job — least privilege for `benchmark.yml` and `release.yml`.
- Documents every elevated permission with an inline comment naming the action that needs it (resolves zizmor's `undocumented-permissions`).
- Adds `concurrency` groups to every workflow: `cancel-in-progress: true` for branch/PR CI (`browser`, `nodejs`), `false` for release/scheduled jobs (`release`, `benchmark`, `dependency-maintenance`), PR-only cancellation for `zizmor`.
- Names every previously-anonymous job.
- Extends `zizmor.yml` with a weekly `schedule` and `workflow_dispatch` so newly-published advisories against pinned action SHAs are caught even when no workflow file changes.

Verified with `zizmor .github/workflows/` — no findings. Three remaining `--persona=pedantic` findings are low-confidence suggestions to replace SHA-pinned `peter-evans/create-pull-request` with hand-rolled `gh pr create` scripts; keeping the action.

## Test plan
- [ ] CI green on this PR (the zizmor workflow itself should run against the workflow changes)
- [ ] No regressions in Node CI / Browser Integration Tests
- [ ] Confirm the next scheduled `Benchmark` / `Dependency Maintenance` run still opens its PR (write perms now job-scoped)