### PR TITLE
fix(ci): install Playwright browsers matching Storybook test-runner

### DIFF
--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -24,6 +24,8 @@ jobs:
         run: |
           cd libraries/sql.js-browser-integration-test
           npx playwright install --with-deps chromium firefox webkit
+          cd ../react-components2
+          npx playwright install --with-deps chromium firefox webkit
       - name: build
         run: |
           npx turbo run --filter=@dossierhq/sql.js-browser-integration-test --filter=@dossierhq/react-components2 lint check-types build test test-integration

--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -100,7 +100,7 @@
     },
     "libraries/react-components2": {
       "ignore": ["src/components/ui/**"],
-      "ignoreDependencies": ["concurrently", "wait-on"],
+      "ignoreDependencies": ["concurrently", "wait-on", "playwright"],
     },
     "libraries/test-data": {
       "entry": ["src/**/*-generator.ts", "src/**/schema-types.ts"],

--- a/libraries/react-components2/package.json
+++ b/libraries/react-components2/package.json
@@ -97,6 +97,7 @@
     "chromatic": "~16.3.0",
     "concurrently": "~9.2.0",
     "eslint": "~10.4.0",
+    "playwright": "~1.59.1",
     "postcss": "~8.5.10",
     "postcss-cli": "~11.0.1",
     "postcss-load-config": "^6.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1526,6 +1526,9 @@ importers:
       eslint:
         specifier: ~10.4.0
         version: 10.4.0(jiti@2.7.0)
+      playwright:
+        specifier: ~1.59.1
+        version: 1.59.1
       postcss:
         specifier: ~8.5.10
         version: 8.5.15


### PR DESCRIPTION
## Problem

Browser integration tests fail with:

```
Error: Executable doesn't exist at /home/runner/.cache/ms-playwright/firefox-1522/firefox/firefox
Failed to launch browser.
```

(seen on #1672, [run 26330382175](https://github.com/dossierhq/dossierhq/actions/runs/26330382175/job/77589907375))

## Root cause

The workflow installs Playwright browsers only from `libraries/sql.js-browser-integration-test`, which pins `@playwright/test ~1.59.1` (firefox **1511**). But `@storybook/test-runner` depends on `playwright: ^1.14.0`, which floats to **1.60.0** (firefox **1522**) whenever the lockfile is regenerated — and those browsers were never installed. `react-components2` doesn't declare Playwright directly, so the install step couldn't target the right version.

## Fix

- Declare `playwright` as a direct devDependency of `react-components2`, pinned to `~1.59.1`. This dedupes with the test-runner's transitive `playwright` (one version repo-wide) and makes `npx playwright` resolve locally in that package. Dependabot now manages this version going forward.
- Install browsers from `react-components2` too, with the same simple `npx playwright install --with-deps chromium firefox webkit`.
- `.knip.jsonc`: ignore the new `playwright` dep (used only by CI, not imported).

Once this lands, the dependabot Storybook PR (#1672) will no longer float Playwright to 1.60.0 on rebase, resolving the failure there.