### PR TITLE
chore: upgrade to pnpm 11

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -2,4 +2,4 @@ bun           1.3.13
 deno          2.7.12
 nodejs        25.9.0
 libsql-server libsql-server-v0.24.31
-pnpm          10.33.2
+pnpm          11.8.0

--- a/package.json
+++ b/package.json
@@ -44,5 +44,5 @@
     "turbo": "^2.9.15",
     "typescript": "~6.0.3"
   },
-  "packageManager": "pnpm@10.33.2"
+  "packageManager": "pnpm@11.8.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,20 +11,6 @@ minimumReleaseAge: 1440
 minimumReleaseAgeExclude: []
 blockExoticSubdeps: true
 
-onlyBuiltDependencies:
-  - "@parcel/watcher"
-  - "@sentry/cli"
-  - "@swc/core"
-  - "@tailwindcss/oxide"
-  - "better-sqlite3"
-  - "esbuild"
-  - "oxc-resolver"
-  - "sharp"
-  - "unrs-resolver"
-
-ignoredBuiltDependencies:
-  - browser-tabs-lock
-
 overrides:
   "@babel/core@7.26.9": "7.26.10"
   "@babel/helpers@7.26.9": "7.26.10"
@@ -43,3 +29,15 @@ overrides:
   "webpack@5.97.1": "~5.104.1"
   "yaml@2.7.1": "~2.8.3"
   "yaml@2.8.2": "~2.8.3"
+
+allowBuilds:
+  "@parcel/watcher": true
+  "@sentry/cli": true
+  "@swc/core": true
+  "@tailwindcss/oxide": true
+  better-sqlite3: true
+  esbuild: true
+  oxc-resolver: true
+  sharp: true
+  unrs-resolver: true
+  browser-tabs-lock: false


### PR DESCRIPTION
## Summary

Upgrades the package manager from pnpm **10.33.2** → **11.8.0** (latest pnpm 11).

## Changes

- **`.tool-versions`** — bump `pnpm` to `11.8.0` (mise-action in CI reads this).
- **`package.json`** — `packageManager` → `pnpm@11.8.0`.
- **`pnpm-workspace.yaml`** — migrate the build-script allowlist. pnpm 11 replaces `onlyBuiltDependencies` + `ignoredBuiltDependencies` with a single `allowBuilds` map. Previously-allowed deps map to `true`, `browser-tabs-lock` to `false`.

## Notes

- Node 25.9.0 satisfies pnpm 11's new Node 22+ requirement.
- Lockfile format is unchanged (still v9.0).
- pnpm 11 prompts to purge `node_modules` on the major upgrade; GitHub Actions sets `CI=true` automatically, so the purge is auto-confirmed and CI is unaffected.

## Verification

- `pnpm install` runs clean (exit 0); all native build scripts (better-sqlite3, sharp, @swc/core, esbuild, @parcel/watcher, unrs-resolver, @sentry/cli) execute — the "Ignored build scripts" warning that appeared before the `allowBuilds` migration is gone.
- Workspace resolution verified across all 42 projects.