### PR TITLE
fix(deps): Repair broken pnpm-lock.yaml eslint peer resolution

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1011,7 +1011,7 @@ importers:
         version: 10.0.1(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))
       '@next/eslint-plugin-next':
         specifier: ~16.3.0
-        version: 16.3.0(eslint@10.7.0(jiti@2.7.0)(supports-color@8.1.1))
+        version: 16.3.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))
       '@vitest/eslint-plugin':
         specifier: ~1.6.18
         version: 1.6.18(@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)(vitest@4.1.7)
@@ -13303,9 +13303,9 @@ snapshots:
       eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.7.0(jiti@2.7.0)(supports-color@8.1.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))':
     dependencies:
-      eslint: 10.7.0(jiti@2.7.0)(supports-color@8.1.1)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -14434,9 +14434,9 @@ snapshots:
 
   '@next/env@16.3.0': {}
 
-  '@next/eslint-plugin-next@16.3.0(eslint@10.7.0(jiti@2.7.0)(supports-color@8.1.1))':
+  '@next/eslint-plugin-next@16.3.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0(jiti@2.7.0)(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))
       fast-glob: 3.3.1
     transitivePeerDependencies:
       - eslint


### PR DESCRIPTION
Fixes CI on `main`, which is currently red across Node CI, Browser Integration Tests and Release.

## Problem

All three workflows fail at their first step, `pnpm install --frozen-lockfile`:

```
[ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY] Broken lockfile: no entry for
'eslint@10.7.0(jiti@2.7.0)(supports-color@8.1.1)' in pnpm-lock.yaml
```

Two dependabot PRs landed about two minutes apart:

- #1790 (eslint group) bumped eslint `10.7.0` → `10.8.0`
- #1792 (next group) had been resolved against eslint `10.7.0` and merged right after, without re-resolving

The resulting lockfile is internally inconsistent: `@next/eslint-plugin-next@16.3.0` and its `@eslint-community/eslint-utils@4.9.1` dependency are still pinned to the `eslint@10.7.0` peer context, but the only `eslint` snapshot present is `10.8.0`. `--frozen-lockfile` refuses to proceed.

## Change

Re-resolves those entries against eslint `10.8.0` — 5 lines in `pnpm-lock.yaml`, no `package.json` changes.

Note on method: `pnpm install --lockfile-only --fix-lockfile` produces the same correct 5-line fix but *also* silently strips `hasBin: true` from 90 packages (it cannot see that metadata without fetching), which would break bin linking. That result was discarded in favour of a full `pnpm install --no-frozen-lockfile`, which yields the same 5 lines with no collateral changes.

## Verification

- `pnpm install --frozen-lockfile` — the exact command CI failed on — now passes
- `npx eslint .` in `examples/next-web` (a `@next/eslint-plugin-next` consumer) exits 0

The full Node CI build was not run locally as it requires a Postgres instance, but the failure was entirely in the install step, so nothing downstream of it ever executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NvGwrs5Jr6xBb9fWp5fd8

---
_Generated by [Claude Code](https://claude.ai/code/session_015NvGwrs5Jr6xBb9fWp5fd8)_