### PR TITLE
fix(libsql): stop sqld integration tests from timing out on CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -43,6 +43,14 @@ jobs:
         env:
           TURBO_TEAM: ${{ secrets.DOSSIERHQ_TURBO_TEAM }}
           TURBO_TOKEN: ${{ secrets.DOSSIERHQ_TURBO_TOKEN }}
+      - name: upload sqld logs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sqld-logs
+          path: libraries/libsql/databases/sqld-*/log.txt
+          if-no-files-found: ignore
+          retention-days: 7
       - name: knip
         run: npm run knip || true
       - name: check for uncommitted changes after build

--- a/libraries/libsql/src/test/TestUtils.ts
+++ b/libraries/libsql/src/test/TestUtils.ts
@@ -4,7 +4,9 @@ import { describe, it } from 'vitest';
 export function registerTestSuite(testSuiteName: string, testSuite: TestSuite): void {
   describe(testSuiteName, () => {
     for (const [testName, testFunction] of Object.entries(testSuite)) {
-      it(testName, { timeout: testFunction.timeout === 'long' ? 30_000 : 20_000 }, testFunction);
+      // 'long' tests set up their own servers (SyncTest starts two sqld processes), so the
+      // timeout has to leave room for SqldRunner's health check to expire and report its log.
+      it(testName, { timeout: testFunction.timeout === 'long' ? 60_000 : 20_000 }, testFunction);
     }
   });
 }

--- a/libraries/libsql/src/test/integration/sqld/AdminEntityTest.test.ts
+++ b/libraries/libsql/src/test/integration/sqld/AdminEntityTest.test.ts
@@ -22,7 +22,7 @@ beforeAll(async () => {
   readOnlyEntityRepository = (
     await createReadOnlyEntityRepository(createDossierClientProvider(serverInit.server))
   ).valueOrThrow();
-}, 30_000);
+});
 afterAll(async () => {
   if (serverInit) {
     (await serverInit.server.shutdown()).throwIfError();

--- a/libraries/libsql/src/test/integration/sqld/PublishedEntityTest.test.ts
+++ b/libraries/libsql/src/test/integration/sqld/PublishedEntityTest.test.ts
@@ -24,7 +24,7 @@ beforeAll(async () => {
   readOnlyEntityRepository = (
     await createReadOnlyEntityRepository(createSharedDossierClientProvider(serverInit.server))
   ).valueOrThrow();
-}, 30_000);
+});
 afterAll(async () => {
   if (serverInit) {
     (await serverInit.server.shutdown()).throwIfError();

--- a/libraries/libsql/src/test/integration/sqld/SqldRunner.ts
+++ b/libraries/libsql/src/test/integration/sqld/SqldRunner.ts
@@ -7,11 +7,17 @@ export interface SqldProcess {
   close(): void;
 }
 
-// All sqld test files run in parallel and each spawns one or more sqld processes,
-// so on a busy CI runner cold start can take noticeably longer than locally. Give
-// the health check a generous deadline rather than a tight retry count.
-const HEALTH_TIMEOUT_MS = 30_000;
+// The sqld test files run one at a time (see fileParallelism in vitest.config.js), but a
+// cold start on a busy CI runner is still slower than locally. Give the health check a
+// generous deadline rather than a tight retry count. It has to stay comfortably below the
+// enclosing vitest timeouts (hooks, and the per-test timeout in TestUtils, where SyncTest
+// spawns two processes within one test) so that a failure reports the sqld log rather than
+// being cut short by vitest.
+const HEALTH_TIMEOUT_MS = 15_000;
 const HEALTH_POLL_INTERVAL_MS = 100;
+// A socket that accepts the connection but never answers (e.g. an unrelated process holding
+// the port) would otherwise stall a single fetch for the whole deadline.
+const HEALTH_REQUEST_TIMEOUT_MS = 1_000;
 
 export async function createSqldProcess(name: string, address: string): Promise<SqldProcess> {
   const directory = `databases/sqld-${name}`;
@@ -21,19 +27,26 @@ export async function createSqldProcess(name: string, address: string): Promise<
 
   await mkdir(directory, { recursive: true });
 
-  const logStream = createWriteStream(logPath, { flags: 'a' });
+  // Truncate: the log is read back verbatim when the health check fails, and output from a
+  // previous run mixed into that message is actively misleading.
+  const logStream = createWriteStream(logPath, { flags: 'w' });
 
   const sqld = spawn('sqld', ['--db-path', dbPath, '--http-listen-addr', address]);
 
-  let spawnError: Error | null = null;
+  let startupError: Error | null = null;
   sqld.on('error', (error) => {
-    spawnError = error;
+    startupError = new Error(`sqld failed to spawn: ${error.message}`);
+  });
+  // An sqld that dies during startup (port in use, corrupt database, missing tool) otherwise
+  // just looks like a slow server until the deadline expires. Fail immediately instead.
+  sqld.on('exit', (code, signal) => {
+    startupError = new Error(`sqld exited during startup (code ${code}, signal ${signal})`);
   });
 
   sqld.stdout.pipe(logStream);
   sqld.stderr.pipe(logStream);
 
-  await waitForHealthy(url, logStream, logPath, () => spawnError);
+  await waitForHealthy(url, logStream, logPath, () => startupError);
 
   return {
     url,
@@ -47,19 +60,23 @@ async function waitForHealthy(
   url: string,
   logStream: NodeJS.WritableStream,
   logPath: string,
-  getSpawnError: () => Error | null,
+  getStartupError: () => Error | null,
 ) {
   const healthUrl = `${url}/health`;
   const deadline = Date.now() + HEALTH_TIMEOUT_MS;
   let attempts = 0;
   while (Date.now() < deadline) {
-    const spawnError = getSpawnError();
-    if (spawnError) {
-      throw new Error(`Failed to start sqld for ${healthUrl}: ${spawnError.message}`);
+    const startupError = getStartupError();
+    if (startupError) {
+      throw new Error(
+        `Failed to start sqld for ${healthUrl}: ${startupError.message}.\nsqld log:\n${await readLog(logPath)}`,
+      );
     }
     attempts++;
     try {
-      const res = await fetch(healthUrl);
+      const res = await fetch(healthUrl, {
+        signal: AbortSignal.timeout(HEALTH_REQUEST_TIMEOUT_MS),
+      });
       if (res.ok) {
         logStream.write(`Server is healthy on ${healthUrl} (after ${attempts} attempts)\n`);
         return;
@@ -70,8 +87,12 @@ async function waitForHealthy(
     }
     await new Promise((resolve) => setTimeout(resolve, HEALTH_POLL_INTERVAL_MS));
   }
-  const log = await readFile(logPath, 'utf8').catch(() => '(no log available)');
   throw new Error(
-    `Server is not responding on ${healthUrl} after ${HEALTH_TIMEOUT_MS}ms (${attempts} attempts).\nsqld log:\n${log}`,
+    `Server is not responding on ${healthUrl} after ${HEALTH_TIMEOUT_MS}ms (${attempts} attempts).\nsqld log:\n${await readLog(logPath)}`,
   );
+}
+
+async function readLog(logPath: string) {
+  const log = await readFile(logPath, 'utf8').catch(() => null);
+  return log ? log : '(no log available)';
 }

--- a/libraries/libsql/vitest.config.js
+++ b/libraries/libsql/vitest.config.js
@@ -1,6 +1,31 @@
 export default {
   test: {
-    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     watch: false,
+    projects: [
+      {
+        test: {
+          name: 'file',
+          include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+          exclude: ['**/node_modules/**', 'src/test/integration/sqld/**'],
+          watch: false,
+        },
+      },
+      {
+        test: {
+          name: 'sqld',
+          include: ['src/test/integration/sqld/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+          watch: false,
+          // Each file spawns one or more real sqld processes. Running them all at once
+          // saturates a CI runner (which is also busy with lint/check-types), and every
+          // sqld cold start then misses its health check at the same time. Run the files
+          // one at a time instead; it costs ~10s and removes the contention entirely.
+          fileParallelism: false,
+          // Must stay well above SqldRunner's health-check deadline, so a genuine startup
+          // failure surfaces the sqld log instead of a bare 'hook timed out'.
+          hookTimeout: 60_000,
+          testTimeout: 60_000,
+        },
+      },
+    ],
   },
 };


### PR DESCRIPTION
## Why

All 7 sqld test files failed at once on main in [run 31929133537](https://github.com/dossierhq/dossierhq/actions/runs/31929133537/job/95121694288) — every `createSqldProcess` call timed out waiting for `/health`:

```
7 failed | 8 passed (15 files)
Error: Hook timed out in 30000ms.  ❯ sqld/AdminEntityTest.test.ts:17:1
Error: Hook timed out in 10000ms.  ❯ sqld/AdvisoryLockTest.test.ts:13:1   (+ Auth, Changelog, Schema)
Error: Test timed out in 30000ms.  ❯ SyncTest > sync_allEventsScenario
```

No spawn error, no `EADDRINUSE`, no OOM; ports 9000–9007 are distinct and the eight non-sqld files passed. The run two minutes earlier on the neighbouring commit passed with `AuthTest` in 669 ms. This is the cold-start contention described in aed34daad: the files run in parallel, each spawning a real sqld process, while turbo runs `lint`/`check-types` in the same step — on a 4-vCPU runner none of the servers came up in time.

The logs can't say *why* sqld didn't start, and that is the second half of the problem: `SqldRunner`'s 30s health deadline was longer than the vitest hook timeouts around it, so the `sqld log:` diagnostic added in aed34daad could never print, and `databases/sqld-*/log.txt` was never uploaded.

## What

- **Remove the contention.** `vitest.config.js` splits into a `file` project (unchanged, parallel) and an `sqld` project with `fileParallelism: false`. Measured locally: sqld project 16s serial, full suite 18.9s → 16.8s — it was already bounded by AdminEntityTest.
- **Make the timeout budget coherent** so a failure reports the sqld log. The `sqld` project sets `hookTimeout`/`testTimeout` to 60s (4 of the 7 files were on vitest's 10s default, dying 20s before the health check was allowed to give up), the health deadline drops to 15s, and `TestUtils`' `'long'` timeout rises to 60s for SyncTest's two servers. The now-redundant `}, 30_000)` hook arguments are gone.
- **Fail fast when sqld dies during startup** instead of waiting out the deadline as if it were merely slow.
- **Give each health request a 1s timeout** — a socket that accepts but never answers stalled a single `fetch` for the entire deadline (`1 attempts` in 15s).
- **Truncate the sqld log per run**, so the failure message can't report output from a previous run.
- **Upload `databases/sqld-*/log.txt`** as an artifact on CI failure.

## Verification

- `npx turbo run --filter=@dossierhq/libsql lint check-types build test test-integration` → 22/22 tasks, 15 files, 803 tests passing; eslint and `tsc --noEmit` clean.
- Fault injection (holding port 9002, then running AuthTest) now fails in 3.4s with `sqld exited during startup (code 1, signal null)` followed by the sqld banner and `Error: Address already in use` — previously a silent 15s timeout with an empty log.

The CI failure itself could not be reproduced locally. The parallelism change addresses the contention hypothesis; if it recurs, the artifact and the new error messages will name the actual cause.